### PR TITLE
Fix MythicMobs 4.9.0 compatibility.

### DIFF
--- a/src/main/java/com/gmail/berndivader/mythicmobsquests/NMSUtils.java
+++ b/src/main/java/com/gmail/berndivader/mythicmobsquests/NMSUtils.java
@@ -119,7 +119,7 @@ public class NMSUtils {
 			level=0;
 			Bukkit.getLogger().warning("Error getting Level for Mob. Set to 0");
 		}
-    	return (int)level;
+		return (int)((double)level);
     }
 
 }


### PR DESCRIPTION
`NMSUtils.getActiveMobLevel()` needed a fix for `Double` too.